### PR TITLE
string methods implementations and tests + Made result writer publicly visible

### DIFF
--- a/Lambda2Js.Tests/GeneralTests.cs
+++ b/Lambda2Js.Tests/GeneralTests.cs
@@ -308,7 +308,7 @@ namespace Lambda2Js.Tests
         {
             Expression<Func<MyClass, bool>> expr = o => o.Name.Contains("Miguel");
             var js = expr.CompileToJavascript();
-            Assert.AreEqual("Name.indexOf(\"Miguel\")>=0", js);
+            Assert.AreEqual("Name.includes(\"Miguel\")", js);
         }
 
         [TestMethod]
@@ -316,7 +316,7 @@ namespace Lambda2Js.Tests
         {
             Expression<Func<MyClass, bool>> expr = o => "Miguel Angelo Santos Bicudo".Contains(o.Name);
             var js = expr.CompileToJavascript();
-            Assert.AreEqual("(\"Miguel Angelo Santos Bicudo\").indexOf(Name)>=0", js);
+            Assert.AreEqual("(\"Miguel Angelo Santos Bicudo\").includes(Name)", js);
         }
 
         [TestMethod]

--- a/Lambda2Js.Tests/GeneralTests.cs
+++ b/Lambda2Js.Tests/GeneralTests.cs
@@ -320,6 +320,102 @@ namespace Lambda2Js.Tests
         }
 
         [TestMethod]
+        public void StringStartsWith()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.StartsWith("Test");
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.startsWith(\"Test\")", js);
+        }
+
+        [TestMethod]
+        public void StringEndsWith()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.EndsWith("Test");
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.endsWith(\"Test\")", js);
+        }
+
+        [TestMethod]
+        public void StringToLower()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.ToLower() == "test";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.toLowerCase()===\"test\"", js);
+        }
+
+        [TestMethod]
+        public void StringToUpper()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.ToUpper() == "TEST";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.toUpperCase()===\"TEST\"", js);
+        }
+
+        [TestMethod]
+        public void StringTrim()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.Trim() == "test";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.trim()===\"test\"", js);
+        }
+
+        [TestMethod]
+        public void StringTrimStart()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.TrimStart() == "test";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.trimLeft()===\"test\"", js);
+        }
+
+        [TestMethod]
+        public void StringTrimEnd()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.TrimEnd() == "test";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.trimRight()===\"test\"", js);
+        }
+
+        [TestMethod]
+        public void StringSubString()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.Substring(1) == "est";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.substring(1)===\"est\"", js);
+        }
+
+        [TestMethod]
+        public void StringPadLeft()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.PadLeft(1) == "est";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.padStart(1)===\"est\"", js);
+        }
+
+        [TestMethod]
+        public void StringPadRight()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.PadRight(1) == "est";
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.padEnd(1)===\"est\"", js);
+        }
+
+        [TestMethod]
+        public void StringLastIndexOf()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.LastIndexOf("!") == 1;
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.lastIndexOf(\"!\")===1", js);
+        }
+
+        [TestMethod]
+        public void StringIndexOf()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Name.IndexOf("!") == 1;
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual("Name.indexOf(\"!\")===1", js);
+        }
+
+        [TestMethod]
         public void StringIndexer1()
         {
             Expression<Func<string, char>> expr = s => s[0];

--- a/Lambda2Js.Tests/StaticStringMethodTests.cs
+++ b/Lambda2Js.Tests/StaticStringMethodTests.cs
@@ -91,7 +91,7 @@ namespace Lambda2Js.Tests
                     JsCompilationFlags.BodyOnly | JsCompilationFlags.ScopeParameter,
                     new[] { new StaticStringMethods() }));
 
-            Assert.AreEqual("(Name+\":\"+(Age+10)).indexOf(\"30\")>=0", js);
+            Assert.AreEqual("(Name+\":\"+(Age+10)).includes(\"30\")", js);
         }
 
         [TestMethod]

--- a/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
+++ b/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
@@ -803,6 +803,269 @@ namespace Lambda2Js
                         return node;
                     }
                 }
+                else if (node.Method.Name == nameof(string.StartsWith))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".startsWith(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+                        return node;
+
+                    }
+                }
+                else if (node.Method.Name == nameof(string.EndsWith))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".endsWith(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.ToLower))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".toLowerCase(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.ToUpper))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".toUpperCase(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.Trim))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".trim(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.TrimEnd))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".trimRight(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.TrimStart))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".trimLeft(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.Substring))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".substring(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.PadLeft))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".padStart(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.PadRight))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".padEnd(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.LastIndexOf))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".lastIndexOf(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
+                else if (node.Method.Name == nameof(string.IndexOf))
+                {
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                    {
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".indexOf(");
+                        using (this.resultWriter.Operation(0))
+                        {
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
+                            {
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
+                            }
+                        }
+
+                        this.resultWriter.Write(')');
+
+                        return node;
+                    }
+                }
             }
 
             if (node.Method.Name == "ToString" && node.Type == typeof(string) && node.Object != null)

--- a/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
+++ b/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
@@ -778,28 +778,23 @@ namespace Lambda2Js
             {
                 if (node.Method.Name == "Contains")
                 {
-                    using (this.resultWriter.Operation(JavascriptOperationTypes.Comparison))
+                    using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
                     {
-                        using (this.resultWriter.Operation(JavascriptOperationTypes.Call))
+                        using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
+                            this.Visit(node.Object);
+                        this.resultWriter.Write(".includes(");
+                        using (this.resultWriter.Operation(0))
                         {
-                            using (this.resultWriter.Operation(JavascriptOperationTypes.IndexerProperty))
-                                this.Visit(node.Object);
-                            this.resultWriter.Write(".indexOf(");
-                            using (this.resultWriter.Operation(0))
+                            var posStart = this.resultWriter.Length;
+                            foreach (var arg in node.Arguments)
                             {
-                                var posStart = this.resultWriter.Length;
-                                foreach (var arg in node.Arguments)
-                                {
-                                    if (this.resultWriter.Length > posStart)
-                                        this.resultWriter.Write(',');
-                                    this.Visit(arg);
-                                }
+                                if (this.resultWriter.Length > posStart)
+                                    this.resultWriter.Write(',');
+                                this.Visit(arg);
                             }
-
-                            this.resultWriter.Write(')');
                         }
 
-                        this.resultWriter.Write(">=0");
+                        this.resultWriter.Write(')');
                         return node;
                     }
                 }


### PR DESCRIPTION
1- All implemented methods have equivalent JavaScript version based on ECMA
They work on modern browsers, and on older browsers you can use core-js
2- I replaced indexOf()>=0 with includes method. See https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/includes
It is supported in modern browsers, and it has a easy to use polyfill. So I recommend to use that instead of indexOf
3- I need to inherit from JavascriptCompilerExpressionVisitor class. To make this inheritance more useful, I made result writer public, but you can make it protected as well.
Please create a nugget package based on recent changes ASAP if you're agree with the changes. :D
Thanks in advance. I really appreciate your codes.