### PR TITLE
Support comparing T with Nullable<T>

### DIFF
--- a/Lambda2Js.Tests/GeneralTests.cs
+++ b/Lambda2Js.Tests/GeneralTests.cs
@@ -667,6 +667,14 @@ namespace Lambda2Js.Tests
             // TODO: this case could be optimized
             Assert.AreEqual(@"Phones.length===0?1+10:2+10", js);
         }
+
+        [TestMethod]
+        public void CanCompareToNullable()
+        {
+            Expression<Func<MyClass, bool>> expr = o => o.Count == 1;
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual(@"Count===1", js);
+        }
     }
 
     class MyClass
@@ -675,6 +683,7 @@ namespace Lambda2Js.Tests
         public Dictionary<string, Phone> PhonesByName { get; set; }
         public string Name { get; set; }
         public int Age { get; set; }
+        public int? Count { get; set; }
     }
 
     class Phone

--- a/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
+++ b/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
@@ -101,6 +101,10 @@ namespace Lambda2Js
                             leftVal.Type);
                         rightVal = binary.Right;
                     }
+                    else
+                    {
+                        return node;
+                    }
 
                     return Expression.MakeBinary(node.NodeType, leftVal, rightVal);
                 }


### PR DESCRIPTION
comparing T with Nullable(T) fails with System.InvalidOperationException :

System.InvalidOperationException: The binary operator Equal is not defined for the types 'System.Nullable`1[System.Int32]' and 'System.Int32'.
   at System.Linq.Expressions.Expression.GetEqualityComparisonOperator(ExpressionType binaryType, String opName, Expression left, Expression right, Boolean liftToNull)
   at System.Linq.Expressions.Expression.Equal(Expression left, Expression right, Boolean liftToNull, MethodInfo method)
   at System.Linq.Expressions.Expression.MakeBinary(ExpressionType binaryType, Expression left, Expression right, Boolean liftToNull, MethodInfo method, LambdaExpression conversion)
   at System.Linq.Expressions.Expression.MakeBinary(ExpressionType binaryType, Expression left, Expression right)
   at Lambda2Js.JavascriptCompilerExpressionVisitor.PreprocessNode(Expression node) in C:\work\lambda2js\Lambda2Js\JavascriptCompilerExpressionVisitor.cs:line 106
   at Lambda2Js.JavascriptCompilerExpressionVisitor.Visit(Expression node) in C:\work\lambda2js\Lambda2Js\JavascriptCompilerExpressionVisitor.cs:line

this is because we explicitly call MakeBinary() with expressions of different types

fixed it by simply returning the original node instead of calling MakeBinary() in the case that rightVal.Type != leftVal.Type but their values are not changed inside the if clause (both are not numeric constant enums). 
also added a test case and made sure that all the tests pass