### PR TITLE
Fix resolving member name when JsonProperty attribute defines no property name

### DIFF
--- a/Lambda2Js.Tests/CustomClassMethodTests.cs
+++ b/Lambda2Js.Tests/CustomClassMethodTests.cs
@@ -36,6 +36,9 @@ namespace Lambda2Js.Tests
 
             [JsonProperty(PropertyName = "otherName2")]
             public string Custom2 { get; set; }
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public string Custom3 { get; set; }
         }
 
         public class MyCustomClassMethods : JavascriptConversionExtension
@@ -161,6 +164,14 @@ namespace Lambda2Js.Tests
             Expression<Func<MyCustomClass, string>> expr = o => o.Custom2;
             var js = expr.CompileToJavascript();
             Assert.AreEqual(@"otherName2", js);
+        }
+
+        [TestMethod]
+        public void CustomMetadata3()
+        {
+            Expression<Func<MyCustomClass, string>> expr = o => o.Custom3;
+            var js = expr.CompileToJavascript();
+            Assert.AreEqual(@"Custom3", js);
         }
 
         public class MyClassBase

--- a/Lambda2Js/AttributeJavascriptMetadataProvider.cs
+++ b/Lambda2Js/AttributeJavascriptMetadataProvider.cs
@@ -109,9 +109,16 @@ namespace Lambda2Js
             var type = attr.GetType();
             var accessor = GetAccessors(type);
 
+            var memberName = accessor.PropertyNameGetter?.Invoke(attr);
+
+            if (string.IsNullOrEmpty(memberName))
+            {
+                return null;
+            }
+
             return new JavascriptMemberAttribute
             {
-                MemberName = accessor.PropertyNameGetter?.Invoke(attr),
+                MemberName = memberName,
             };
         }
 


### PR DESCRIPTION
When target is class that has JsonProperty attribute to used for other purposes that renaming the property, Lambda2JS incorrectly tries to resolve new property name that will be null and will trip generation later on.