### PR TITLE
support NotEqual expressions between Enum (as string) and constant

### DIFF
--- a/Lambda2Js.Tests/EnumTests.cs
+++ b/Lambda2Js.Tests/EnumTests.cs
@@ -155,6 +155,28 @@ namespace Lambda2Js.Tests
                     new EnumConversionExtension(EnumOptions.FlagsAsArray | EnumOptions.UseStrings)));
             Assert.AreEqual(@"[""B"",""A""]", js);
         }
+
+        [TestMethod]
+        public void EnumAsStringEquals()
+        {
+            Expression<Func<MyClassWithEnum, bool>> expr = doc => doc.SomeFlagsEnum == SomeFlagsEnum.B;
+            var js = expr.CompileToJavascript(
+                new JavascriptCompilationOptions(
+                    JsCompilationFlags.BodyOnly,
+                    new EnumConversionExtension(EnumOptions.UseStrings)));
+            Assert.AreEqual(@"doc.SomeFlagsEnum===""B""", js);
+        }
+
+        [TestMethod]
+        public void EnumAsStringNotEquals()
+        {
+            Expression<Func<MyClassWithEnum, bool>> expr = doc => doc.SomeFlagsEnum != SomeFlagsEnum.B;
+            var js = expr.CompileToJavascript(
+                new JavascriptCompilationOptions(
+                    JsCompilationFlags.BodyOnly,
+                    new EnumConversionExtension(EnumOptions.UseStrings)));
+            Assert.AreEqual(@"doc.SomeFlagsEnum!==""B""", js);
+        }
     }
 
     public class MyCustomClassEnumMethods : JavascriptConversionExtension

--- a/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
+++ b/Lambda2Js/JavascriptCompilerExpressionVisitor.cs
@@ -80,7 +80,8 @@ namespace Lambda2Js
                 || node.NodeType == ExpressionType.ExclusiveOr
                 || node.NodeType == ExpressionType.OrAssign
                 || node.NodeType == ExpressionType.AndAssign
-                || node.NodeType == ExpressionType.ExclusiveOrAssign)
+                || node.NodeType == ExpressionType.ExclusiveOrAssign
+                || node.NodeType == ExpressionType.NotEqual)
             {
                 var binary = (BinaryExpression)node;
                 var left = binary.Left as UnaryExpression;


### PR DESCRIPTION
this works as expected :
```
Expression<Func<MyClassWithEnum, bool>> expr = doc => doc.SomeFlagsEnum == SomeFlagsEnum.B;
var js = expr.CompileToJavascript(
	new JavascriptCompilationOptions(
		JsCompilationFlags.BodyOnly,
		new EnumConversionExtension(EnumOptions.UseStrings)));
```
returns `"doc.SomeFlagsEnum===""B"""`

this didn't work as expected :
```
Expression<Func<MyClassWithEnum, bool>> expr = doc => doc.SomeFlagsEnum != SomeFlagsEnum.B;
var js = expr.CompileToJavascript(
	new JavascriptCompilationOptions(
		JsCompilationFlags.BodyOnly,
		new EnumConversionExtension(EnumOptions.UseStrings)));
```
returned `"doc.SomeFlagsEnum!==2"`

I've added `ExpressionType.NotEqual`  to the condition in `PreprocessNode()` and now it works as expected